### PR TITLE
Added new rule for IFlow name checks

### DIFF
--- a/src/dk/mwittrock/cpilint/RulesFile.java
+++ b/src/dk/mwittrock/cpilint/RulesFile.java
@@ -22,6 +22,7 @@ import dk.mwittrock.cpilint.rules.ClientCertSenderChannelAuthNotAllowedRuleFacto
 import dk.mwittrock.cpilint.rules.CsrfProtectionRequiredRuleFactory;
 import dk.mwittrock.cpilint.rules.DuplicateResourcesNotAllowedRuleFactory;
 import dk.mwittrock.cpilint.rules.IflowDescriptionRequiredRuleFactory;
+import dk.mwittrock.cpilint.rules.IflowNameMatchesRuleFactory;
 import dk.mwittrock.cpilint.rules.JavaArchivesRuleFactory;
 import dk.mwittrock.cpilint.rules.MappingTypesRuleFactory;
 import dk.mwittrock.cpilint.rules.MatchingProcessDirectChannelsRequiredRuleFactory;
@@ -57,6 +58,7 @@ public final class RulesFile {
 		ruleFactories.add(new MultiConditionTypeRoutersNotAllowedRuleFactory());
 		ruleFactories.add(new MatchingProcessDirectChannelsRequiredRuleFactory());
 		ruleFactories.add(new DuplicateResourcesNotAllowedRuleFactory());
+		ruleFactories.add(new IflowNameMatchesRuleFactory());
 	}
 	
 	private RulesFile() {

--- a/src/dk/mwittrock/cpilint/issues/IflowNameMatchesIssue.java
+++ b/src/dk/mwittrock/cpilint/issues/IflowNameMatchesIssue.java
@@ -1,0 +1,11 @@
+package dk.mwittrock.cpilint.issues;
+
+import dk.mwittrock.cpilint.artifacts.IflowArtifactTag;
+
+public final class IflowNameMatchesIssue extends ArtifactIssueBase {
+
+	public IflowNameMatchesIssue(IflowArtifactTag tag, String patternString) {
+		super(tag, patternString.format("Iflow name does not match the required pattern (%s) for Iflow names.", patternString));
+	}
+
+}

--- a/src/dk/mwittrock/cpilint/rules/IflowNameMatchesRule.java
+++ b/src/dk/mwittrock/cpilint/rules/IflowNameMatchesRule.java
@@ -1,0 +1,27 @@
+package dk.mwittrock.cpilint.rules;
+
+import dk.mwittrock.cpilint.artifacts.IflowArtifact;
+import dk.mwittrock.cpilint.artifacts.IflowArtifactTag;
+import dk.mwittrock.cpilint.issues.IflowNameMatchesIssue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class IflowNameMatchesRule extends RuleBase {
+
+	private Pattern namePattern;
+
+	IflowNameMatchesRule(Pattern namePattern) {
+		this.namePattern = namePattern;
+	}
+
+	@Override
+	public void inspect(IflowArtifact iflow) {
+		IflowArtifactTag tag = iflow.getTag();
+		Matcher matcher = this.namePattern.matcher(tag.getName());
+		if (!matcher.find()){
+			consumer.consume(new IflowNameMatchesIssue(tag, namePattern.toString()));
+		}
+	}
+
+}

--- a/src/dk/mwittrock/cpilint/rules/IflowNameMatchesRuleFactory.java
+++ b/src/dk/mwittrock/cpilint/rules/IflowNameMatchesRuleFactory.java
@@ -1,0 +1,44 @@
+package dk.mwittrock.cpilint.rules;
+
+import dk.mwittrock.cpilint.RulesFileError;
+import org.dom4j.Element;
+
+import java.util.regex.Pattern;
+
+public final class IflowNameMatchesRuleFactory implements RuleFactory {
+
+	private static final String PATTERN_ELEMENT_NAME = "naming-pattern";
+
+	@Override
+	public boolean canCreateFrom(Element e) {
+		return e.getName().equals("iflow-matches-name");
+	}
+
+	@Override
+	public Rule createFrom(Element e) {
+
+		String ruleElementName = e.getName();
+		if (!canCreateFrom(e)) {
+			throw new RuleFactoryError(String.format("Cannot create Rule object from element '%s'", e.getName()));
+		}
+
+		/*
+		 * Check for existence of configuration element
+		 */
+		if (e.elements(PATTERN_ELEMENT_NAME).isEmpty()) {
+			throw new RulesFileError(String.format("Element '%s' must contain exact one '%s' element", ruleElementName, PATTERN_ELEMENT_NAME));
+		}
+
+		/*
+		 * Extract the matching pattern
+		 */
+		try {
+			Pattern namePattern = Pattern.compile(e.elements(PATTERN_ELEMENT_NAME).get(0).getText(), Pattern.DOTALL);
+			return new IflowNameMatchesRule(namePattern);
+		} catch (Exception ex) {
+			throw new RulesFileError(String.format("Element '%s' must contain a valid Regular Expression (RegEx)", PATTERN_ELEMENT_NAME));
+		}
+
+	}
+
+}


### PR DESCRIPTION
This merge request contains a new rule that allows to check an IFlow's name against a Regex pattern. Feel free to merge it. If you want me to change something, let me know. Feedback is appreciated.